### PR TITLE
Fix the docs build on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,15 @@ readme = "README.md"
 keywords = ["pmc", "freebsd"]
 repository = "https://github.com/domodwyer/pmc-rs"
 homepage = "https://github.com/domodwyer/pmc-rs"
-documentation = "https://itsallbroken.com/code/docs/pmc-rs/pmc/index.html"
 description = """
 A safe abstraction for interacting with Performance Monitor Counters on FreeBSD.
 """
 categories = ["api-bindings"]
+
+[package.metadata.docs.rs]
+targets = [
+  "x86_64-unknown-freebsd",
+]
 
 [lib]
 name = "pmc"


### PR DESCRIPTION
Also, move crates.io's doc link to docs.rs.  It's not required, but why
not?