### PR TITLE
ci: add Cirrus CI pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,12 +3,13 @@ task:
     - name: FreeBSD 11
       freebsd_instance:
         image: freebsd-11-4-release-amd64
-    - name: FreeBSD 12
-      freebsd_instance:
-        image: freebsd-12-2-release-amd64
-    - name: FreeBSD 13
-      freebsd_instance:
-        image: freebsd-13-0-alpha3-amd64
+    # - name: FreeBSD 12
+    #   freebsd_instance:
+    #     image: freebsd-12-2-release-amd64
+    # - name: FreeBSD 13
+    #   freebsd_instance:
+    #     image: freebsd-13-0-alpha3-amd64
+
   setup_script:
     - pkg install -y curl llvm90
     - kldload pmc
@@ -16,6 +17,15 @@ task:
     - sh rustup.sh -y --profile=minimal
     - . $HOME/.cargo/env
     - rustup default stable
+    
+    # Print the state of the CPU PMCs and supported events to help with
+    # debugging.
+    #
+    # NOTE: Cirrus seems to use Google Cloud which DOES NOT support PMCs -
+    # attempting to use them returns EINVAL
+    - pmccontrol -s
+    - pmccontrol -L
+
   test_script:
     - . $HOME/.cargo/env
     - cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+task:
+  matrix:
+    - name: FreeBSD 11
+      freebsd_instance:
+        image: freebsd-11-4-release-amd64
+    - name: FreeBSD 12
+      freebsd_instance:
+        image: freebsd-12-2-release-amd64
+    - name: FreeBSD 13
+      freebsd_instance:
+        image: freebsd-13-0-alpha3-amd64
+  setup_script:
+    - pkg install -y curl llvm90
+    - kldload pmc
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,20 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr 2.3.4",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr 2.3.4",
+ "memchr",
 ]
 
 [[package]]
@@ -40,20 +31,25 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.33.2"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603ed8d8392ace9581e834e26bd09799bf1e989a79bd1aedbb893e72962bdc6e"
+checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
+ "bitflags",
  "cexpr",
  "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
  "lazy_static",
+ "lazycell",
  "log",
  "peeking_take_while",
+ "proc-macro2",
  "quote",
- "regex 0.2.11",
+ "regex",
+ "rustc-hash",
+ "shlex",
  "which",
 ]
 
@@ -64,16 +60,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cc"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
-
-[[package]]
 name = "cexpr"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -92,9 +82,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "0.22.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939a1a34310b120d26eba35c29475933128b0ec58e24b43327f8dbe6036fc538"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
@@ -118,22 +108,22 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.13"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.4.3",
+ "regex",
  "termcolor",
 ]
 
 [[package]]
 name = "glob"
-version = "0.2.11"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hermit-abi"
@@ -160,6 +150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,11 +163,11 @@ checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -186,26 +182,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nom"
-version = "3.2.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "memchr 1.0.2",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -222,7 +210,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pmc-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lazy_static",
  "libc",
@@ -231,12 +219,21 @@ dependencies = [
 
 [[package]]
 name = "pmc-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83be567c47d6356e99cb96ee1a77db18bfee5aae93cab1b009de98850f7ad673"
+checksum = "af6da43f3d0a676db2802e23b3aee9254423570bd6f1065dbff624c4db0f616b"
 dependencies = [
  "bindgen",
  "libc",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -247,21 +244,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.3.15"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-
-[[package]]
-name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
- "aho-corasick 0.6.10",
- "memchr 2.3.4",
- "regex-syntax 0.5.6",
- "thread_local 0.3.6",
- "utf8-ranges",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -270,19 +257,10 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
- "aho-corasick 0.7.15",
- "memchr 2.3.4",
- "regex-syntax 0.6.22",
- "thread_local 1.1.3",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
@@ -290,6 +268,18 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "strsim"
@@ -317,15 +307,6 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
@@ -334,22 +315,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.4"
+name = "unicode-xid"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vec_map"
@@ -358,10 +333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
-name = "which"
-version = "1.0.5"
+name = "version_check"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
 ]

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -5,17 +5,19 @@ use error::{new_error, new_os_error, Error, ErrorKind};
 use scope::Scope;
 use signal;
 
-use std::io;
-use std::ffi::CString;
-use std::sync::{Mutex, Once};
+use pmc_sys::{
+    pmc_allocate, pmc_attach, pmc_id_t, pmc_mode, pmc_read, pmc_release, pmc_rw, pmc_start,
+    pmc_stop,
+};
 use pmc_sys::{pmc_mode_PMC_MODE_SC, pmc_mode_PMC_MODE_TC};
-use pmc_sys::{pmc_allocate, pmc_attach, pmc_id_t, pmc_mode, pmc_read, pmc_release, pmc_rw,
-              pmc_start, pmc_stop};
+use std::ffi::CString;
+use std::io;
+use std::sync::{Mutex, Once};
 
 static SIGNAL_WATCH: Once = Once::new();
 
 lazy_static! {
-	static ref ALLOCATE_LOCK: Mutex<i32> = Mutex::new(42);
+    static ref ALLOCATE_LOCK: Mutex<i32> = Mutex::new(42);
 }
 
 #[derive(Debug)]
@@ -25,21 +27,20 @@ lazy_static! {
 /// # Safety
 ///
 /// `Counter` uses unsafe code and all [`pmc-rs`] code has been thoroughly
-/// tested. However the [`hwpmc(4)`] kernel module itself has questionable safety
-/// and known bugs - [`pmc-rs`] attempts to work around all known issues but
-/// care should be taken.
+/// tested. However the [`hwpmc(4)`] kernel module itself has questionable
+/// safety and known bugs - [`pmc-rs`] attempts to work around all known issues
+/// but care should be taken.
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// # extern crate pmc;
 /// #
 /// # use std::time::Duration;
 /// # use std::thread;
 /// #
 /// # fn test_main() -> Result<(), pmc::error::Error> {
-/// let mut counter =
-///     pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
+/// let mut counter = pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
 ///
 /// // Attach and start the counter.
 /// //
@@ -68,382 +69,374 @@ lazy_static! {
 ///
 /// [`hwpmc(4)`]: https://www.freebsd.org/cgi/man.cgi?query=hwpmc
 /// [`pmc-rs`]: index.html
-///
 pub struct Counter<'a> {
-	pmc_id: Option<pmc_id_t>,
-	event_spec: &'a str,
-	pmc_mode: pmc_mode,
-	running: bool,
-	attached: Vec<u32>,
+    pmc_id: Option<pmc_id_t>,
+    event_spec: &'a str,
+    pmc_mode: pmc_mode,
+    running: bool,
+    attached: Vec<u32>,
 }
 
 impl<'a> Counter<'a> {
-	fn init(&self) -> Result<(), Error> {
-		if unsafe { pmc_sys::pmc_init() } == 0 {
-			return Ok(());
-		}
+    fn init(&self) -> Result<(), Error> {
+        if unsafe { pmc_sys::pmc_init() } == 0 {
+            return Ok(());
+        }
 
-		// Register the signal handler
-		SIGNAL_WATCH.call_once(|| {
-			signal::watch_for(&[libc::SIGBUS, libc::SIGIO]);
-		});
+        // Register the signal handler
+        SIGNAL_WATCH.call_once(|| {
+            signal::watch_for(&[libc::SIGBUS, libc::SIGIO]);
+        });
 
-		match io::Error::raw_os_error(&io::Error::last_os_error()) {
-			Some(libc::ENOENT) => Err(new_os_error(ErrorKind::Init)),
-			Some(libc::ENXIO) => Err(new_os_error(ErrorKind::Unsupported)),
-			Some(libc::EPROGMISMATCH) => Err(new_os_error(ErrorKind::VersionMismatch)),
-			_ => Err(new_os_error(ErrorKind::Unknown)),
-		}
-	}
+        match io::Error::raw_os_error(&io::Error::last_os_error()) {
+            Some(libc::ENOENT) => Err(new_os_error(ErrorKind::Init)),
+            Some(libc::ENXIO) => Err(new_os_error(ErrorKind::Unsupported)),
+            Some(libc::EPROGMISMATCH) => Err(new_os_error(ErrorKind::VersionMismatch)),
+            _ => Err(new_os_error(ErrorKind::Unknown)),
+        }
+    }
 
-	/// Allocates a new Counter.
-	///
-	/// `event_spec` should be an event specifier recognised by the FreeBSD PMC
-	/// subsystem, and must be valid for `scope`.
-	///
-	/// Run `apropos pmc.` on the target system for a full list of supported
-	/// CPUs and their event specifications.
-	///
-	/// `cpu` is either `CPU_ANY` or represents the CPU to allocate the counter
-	/// on. Only events occurring on the specified CPU will increment the
-	/// counter.
-	///
-	/// # Examples
-	///
-	/// Allocate a process-scoped instructions counter, measuring events across
-	/// all CPUs in the system:
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// let mut counter =
-	///     pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	///
-	/// Allocate a system-scoped cycles counter, measuring events on the first
-	/// CPU only (1-based indexing):
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// let mut counter =
-	///     pmc::Counter::new("cycles", &pmc::Scope::System, 1)?;
-	///
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	pub fn new(event_spec: &'a str, scope: &Scope, cpu: i32) -> Result<Self, Error> {
-		let pmc_mode = match *scope {
-			Scope::System => pmc_mode_PMC_MODE_SC,
-			Scope::Process => pmc_mode_PMC_MODE_TC,
-		};
+    /// Allocates a new Counter.
+    ///
+    /// `event_spec` should be an event specifier recognised by the FreeBSD PMC
+    /// subsystem, and must be valid for `scope`.
+    ///
+    /// Run `apropos pmc.` on the target system for a full list of supported
+    /// CPUs and their event specifications.
+    ///
+    /// `cpu` is either `CPU_ANY` or represents the CPU to allocate the counter
+    /// on. Only events occurring on the specified CPU will increment the
+    /// counter.
+    ///
+    /// # Examples
+    ///
+    /// Allocate a process-scoped instructions counter, measuring events across
+    /// all CPUs in the system:
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// let mut counter = pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    ///
+    /// Allocate a system-scoped cycles counter, measuring events on the first
+    /// CPU only (1-based indexing):
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// let mut counter = pmc::Counter::new("cycles", &pmc::Scope::System, 1)?;
+    ///
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    pub fn new(event_spec: &'a str, scope: &Scope, cpu: i32) -> Result<Self, Error> {
+        let pmc_mode = match *scope {
+            Scope::System => pmc_mode_PMC_MODE_SC,
+            Scope::Process => pmc_mode_PMC_MODE_TC,
+        };
 
-		let mut c = Counter {
-			event_spec,
-			pmc_mode,
-			pmc_id: None,
-			running: false,
-			attached: Vec::new(),
-		};
+        let mut c = Counter {
+            event_spec,
+            pmc_mode,
+            pmc_id: None,
+            running: false,
+            attached: Vec::new(),
+        };
 
-		// It appears pmc_allocate isn't thread safe, so take a lock while
-		// calling it
-		let _lock = ALLOCATE_LOCK.lock().unwrap();
+        // It appears pmc_allocate isn't thread safe, so take a lock while
+        // calling it
+        let _lock = ALLOCATE_LOCK.lock().unwrap();
 
-		// Initialise libpmc and check for any signals from hwpmc
-		c.init()?;
-		signal::check()?;
+        // Initialise libpmc and check for any signals from hwpmc
+        c.init()?;
+        signal::check()?;
 
-		let spec = CString::new(c.event_spec).map_err(|_| new_error(ErrorKind::InvalidEventSpec))?;
+        let spec =
+            CString::new(c.event_spec).map_err(|_| new_error(ErrorKind::InvalidEventSpec))?;
 
-		// Allocate the PMC
-		let mut id = 0;
-		if unsafe { pmc_allocate(spec.as_ptr(), c.pmc_mode, 0 as u32, cpu, &mut id) } != 0 {
-			return match io::Error::raw_os_error(&io::Error::last_os_error()) {
-				Some(libc::EINVAL) => Err(new_os_error(ErrorKind::AllocInit)),
-				_ => Err(new_os_error(ErrorKind::Unknown)),
-			};
-		}
+        // Allocate the PMC
+        let mut id = 0;
+        if unsafe { pmc_allocate(spec.as_ptr(), c.pmc_mode, 0 as u32, cpu, &mut id) } != 0 {
+            return match io::Error::raw_os_error(&io::Error::last_os_error()) {
+                Some(libc::EINVAL) => Err(new_os_error(ErrorKind::AllocInit)),
+                _ => Err(new_os_error(ErrorKind::Unknown)),
+            };
+        }
 
-		c.pmc_id = Some(id);
-		Ok(c)
-	}
+        c.pmc_id = Some(id);
+        Ok(c)
+    }
 
-	/// Attach a [`Process`-scoped] counter to a running process. It is an error
-	/// to attach a system-scoped counter to a process.
-	///
-	/// Attaching to PID `0` is treated as a special request to attach to the
-	/// currently running process.
-	///
-	/// # Permissions
-	///
-	/// Internally [`p_candebug(9)`] is called to determine if the user is
-	/// allowed to attach to the requested process - this basically involves
-	/// checking if the sysctl `security.bsd.unprivileged_proc_debug` is
-	/// non-zero to allow users to attach, otherwise restricting the call to
-	/// root.
-	///
-	/// # Examples
-	///
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// # let mut counter =
-	/// #    pmc::Counter::new("cycles", &pmc::Scope::System, 0)?;
-	/// if let Some(e) = counter.attach(0).err() {
-	///     println!("failed to attach to self: {}", e);
-	/// }
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	/// [`p_candebug(9)`]: https://www.freebsd.org/cgi/man.cgi?query=p_candebug&sektion=9
-	/// [`Process`-scoped]: enum.Scope.html#variant.Process
-	///
-	pub fn attach(&mut self, target: u32) -> Result<(), Error> {
-		signal::check()?;
+    /// Attach a [`Process`-scoped] counter to a running process. It is an error
+    /// to attach a system-scoped counter to a process.
+    ///
+    /// Attaching to PID `0` is treated as a special request to attach to the
+    /// currently running process.
+    ///
+    /// # Permissions
+    ///
+    /// Internally [`p_candebug(9)`] is called to determine if the user is
+    /// allowed to attach to the requested process - this basically involves
+    /// checking if the sysctl `security.bsd.unprivileged_proc_debug` is
+    /// non-zero to allow users to attach, otherwise restricting the call to
+    /// root.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// # let mut counter =
+    /// #    pmc::Counter::new("cycles", &pmc::Scope::System, 0)?;
+    /// if let Some(e) = counter.attach(0).err() {
+    ///     println!("failed to attach to self: {}", e);
+    /// }
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`p_candebug(9)`]: https://www.freebsd.org/cgi/man.cgi?query=p_candebug&sektion=9
+    /// [`Process`-scoped]: enum.Scope.html#variant.Process
+    pub fn attach(&mut self, target: u32) -> Result<(), Error> {
+        signal::check()?;
 
-		if self.attached.contains(&target) {
-			return Err(new_error(ErrorKind::AlreadyAttached));
-		}
+        if self.attached.contains(&target) {
+            return Err(new_error(ErrorKind::AlreadyAttached));
+        }
 
-		if self.running {
-			return Err(new_error(ErrorKind::Running));
-		}
+        if self.running {
+            return Err(new_error(ErrorKind::Running));
+        }
 
-		if unsafe { pmc_attach(self.pmc_id.unwrap(), target as pmc_sys::pid_t) } != 0 {
-			return match io::Error::raw_os_error(&io::Error::last_os_error()) {
-				Some(libc::EBUSY) => Err(new_os_error(ErrorKind::BusyTarget)),
-				Some(libc::EEXIST) => Err(new_os_error(ErrorKind::AlreadyAttached)),
-				Some(libc::EPERM) => Err(new_os_error(ErrorKind::Forbidden)),
-				Some(libc::EINVAL) | Some(libc::ESRCH) => Err(new_os_error(ErrorKind::BadTarget)),
-				_ => Err(new_os_error(ErrorKind::Unknown)),
-			};
-		}
+        if unsafe { pmc_attach(self.pmc_id.unwrap(), target as pmc_sys::pid_t) } != 0 {
+            return match io::Error::raw_os_error(&io::Error::last_os_error()) {
+                Some(libc::EBUSY) => Err(new_os_error(ErrorKind::BusyTarget)),
+                Some(libc::EEXIST) => Err(new_os_error(ErrorKind::AlreadyAttached)),
+                Some(libc::EPERM) => Err(new_os_error(ErrorKind::Forbidden)),
+                Some(libc::EINVAL) | Some(libc::ESRCH) => Err(new_os_error(ErrorKind::BadTarget)),
+                _ => Err(new_os_error(ErrorKind::Unknown)),
+            };
+        }
 
-		// TODO: remove attached
+        // TODO: remove attached
 
-		self.attached.push(target);
-		Ok(())
-	}
+        self.attached.push(target);
+        Ok(())
+    }
 
-	#[doc(hidden)]
-	#[allow(unreachable_code)]
-	#[allow(unused_variables)]
-	/// Detach this counter from a process.
-	///
-	/// It is an error to try and detach this counter from a process it was
-	/// never never attached to.
-	///
-	/// Don't use detach due to a hwpmc bug.
-	///
-	pub fn detach(&mut self, target: u32) -> Result<(), Error> {
-		unimplemented!("https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227041");
+    #[doc(hidden)]
+    #[allow(unreachable_code)]
+    #[allow(unused_variables)]
+    /// Detach this counter from a process.
+    ///
+    /// It is an error to try and detach this counter from a process it was
+    /// never never attached to.
+    ///
+    /// Don't use detach due to a hwpmc bug.
+    pub fn detach(&mut self, target: u32) -> Result<(), Error> {
+        unimplemented!("https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227041");
 
-		if !self.attached.contains(&target) {
-			return Err(new_error(ErrorKind::BadTarget));
-		}
+        if !self.attached.contains(&target) {
+            return Err(new_error(ErrorKind::BadTarget));
+        }
 
-		// if unsafe { pmc_detach(self.pmc_id, target as pmc_sys::pid_t) } != 0 {
-		// 	return match io::Error::raw_os_error(&io::Error::last_os_error()) {
-		// 		Some(libc::EINVAL) => Err(new_error(ErrorKind::BadTarget)),
-		// 		Some(libc::ESRCH) => Err(new_error(ErrorKind::BadTarget)),
-		// 		_ => Err(new_os_error(ErrorKind::Unknown)),
-		// 	};
-		// }
+        // if unsafe { pmc_detach(self.pmc_id, target as pmc_sys::pid_t) } != 0 {
+        // 	return match io::Error::raw_os_error(&io::Error::last_os_error()) {
+        // 		Some(libc::EINVAL) => Err(new_error(ErrorKind::BadTarget)),
+        // 		Some(libc::ESRCH) => Err(new_error(ErrorKind::BadTarget)),
+        // 		_ => Err(new_os_error(ErrorKind::Unknown)),
+        // 	};
+        // }
 
-		// Remove any references to target in the attached PID list
-		self.attached.retain(|&pid| pid != target);
-		Ok(())
-	}
+        // Remove any references to target in the attached PID list
+        self.attached.retain(|&pid| pid != target);
+        Ok(())
+    }
 
-	/// Start measuring the `Counter` event.
-	///
-	/// # Support
-	///
-	/// Some sampling events require a log file to be configured which is
-	/// currently unsupported.
-	///
-	/// # Examples
-	///
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// # let mut counter =
-	/// #    pmc::Counter::new("cycles", &pmc::Scope::System, 0)?;
-	///	if let Some(e) = counter.start().err() {
-	/// 	println!("failed to start counter: {}", e);
-	/// }
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	pub fn start(&mut self) -> Result<(), Error> {
-		signal::check()?;
+    /// Start measuring the `Counter` event.
+    ///
+    /// # Support
+    ///
+    /// Some sampling events require a log file to be configured which is
+    /// currently unsupported.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// # let mut counter =
+    /// #    pmc::Counter::new("cycles", &pmc::Scope::System, 0)?;
+    /// if let Some(e) = counter.start().err() {
+    ///     println!("failed to start counter: {}", e);
+    /// }
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    pub fn start(&mut self) -> Result<(), Error> {
+        signal::check()?;
 
-		if self.running {
-			return Err(new_error(ErrorKind::Running));
-		}
+        if self.running {
+            return Err(new_error(ErrorKind::Running));
+        }
 
-		if unsafe { pmc_start(self.pmc_id.unwrap()) } != 0 {
-			return match io::Error::raw_os_error(&io::Error::last_os_error()) {
-				Some(libc::EDOOFUS) => Err(new_os_error(ErrorKind::LogFileRequired)),
-				Some(libc::ENXIO) => Err(new_os_error(ErrorKind::BadScope)),
-				_ => Err(new_os_error(ErrorKind::Unknown)),
-			};
-		}
+        if unsafe { pmc_start(self.pmc_id.unwrap()) } != 0 {
+            return match io::Error::raw_os_error(&io::Error::last_os_error()) {
+                Some(libc::EDOOFUS) => Err(new_os_error(ErrorKind::LogFileRequired)),
+                Some(libc::ENXIO) => Err(new_os_error(ErrorKind::BadScope)),
+                _ => Err(new_os_error(ErrorKind::Unknown)),
+            };
+        }
 
-		self.running = true;
-		Ok(())
-	}
+        self.running = true;
+        Ok(())
+    }
 
-	/// Stop measuring the `Counter` event.
-	pub fn stop(&mut self) -> Result<(), Error> {
-		signal::check()?;
+    /// Stop measuring the `Counter` event.
+    pub fn stop(&mut self) -> Result<(), Error> {
+        signal::check()?;
 
-		if !self.running {
-			return Err(new_error(ErrorKind::NotRunning));
-		}
+        if !self.running {
+            return Err(new_error(ErrorKind::NotRunning));
+        }
 
-		if unsafe { pmc_stop(self.pmc_id.unwrap()) } != 0 {
-			return Err(new_os_error(ErrorKind::Unknown));
-		}
+        if unsafe { pmc_stop(self.pmc_id.unwrap()) } != 0 {
+            return Err(new_os_error(ErrorKind::Unknown));
+        }
 
-		self.running = false;
-		Ok(())
-	}
+        self.running = false;
+        Ok(())
+    }
 
-	/// Read a `Counter` value.
-	///
-	/// A `Counter` can be read at any time (not yet started, running, stopped,
-	/// etc), however the value only increments while a `Counter` is [running].
-	///
-	/// # Examples
-	///
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// # let mut counter =
-	/// #    pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
-	///	# counter.attach(0).unwrap();
-	/// #
-	/// let r1 = counter.read()?;
-	/// # counter.set(42).unwrap();
-	/// let r2 = counter.read()?;
-	///
-	/// assert!(r2 > r1);
-	/// #
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	/// [running]: #method.start
-	///
-	pub fn read(&self) -> Result<u64, Error> {
-		signal::check()?;
+    /// Read a `Counter` value.
+    ///
+    /// A `Counter` can be read at any time (not yet started, running, stopped,
+    /// etc), however the value only increments while a `Counter` is [running].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// # let mut counter =
+    /// #    pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
+    /// 	# counter.attach(0).unwrap();
+    /// #
+    /// let r1 = counter.read()?;
+    /// # counter.set(42).unwrap();
+    /// let r2 = counter.read()?;
+    ///
+    /// assert!(r2 > r1);
+    /// #
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [running]: #method.start
+    pub fn read(&self) -> Result<u64, Error> {
+        signal::check()?;
 
-		let mut value: u64 = 0;
-		if unsafe { pmc_read(self.pmc_id.unwrap(), &mut value) } != 0 {
-			return Err(new_os_error(ErrorKind::Unknown));
-		}
+        let mut value: u64 = 0;
+        if unsafe { pmc_read(self.pmc_id.unwrap(), &mut value) } != 0 {
+            return Err(new_os_error(ErrorKind::Unknown));
+        }
 
-		Ok(value)
-	}
+        Ok(value)
+    }
 
-	/// Set performs an atomic read-and-set, returning the current counter value
-	/// before setting it to value.
-	///
-	/// A counter that is running cannot be set.
-	///
-	/// # Examples
-	///
-	/// ```
-	/// # extern crate pmc;
-	/// #
-	/// # fn test_main() -> Result<(), pmc::error::Error> {
-	/// # let mut counter =
-	/// #    pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
-	///	# counter.attach(0).unwrap();
-	/// #
-	/// # counter.set(42)?;
-	/// # counter.start()?;
-	/// let r1 = counter.read()?;
-	///
-	/// // Do some stuff...
-	///
-	/// counter.stop()?;
-	/// # counter.set(4242)?;
-	/// let r2 = counter.set(0)?;
-	/// let r3 = counter.read()?;
-	///
-	/// assert!(r2 != 0);
-	/// assert!(r2 > r1);
-	/// assert!(r3 == 0);
-	/// #
-	/// #   Ok(())
-	/// # }
-	/// #
-	/// # fn main() {
-	/// #   test_main().unwrap();
-	/// # }
-	/// ```
-	///
-	pub fn set(&mut self, value: u64) -> Result<u64, Error> {
-		signal::check()?;
+    /// Set performs an atomic read-and-set, returning the current counter value
+    /// before setting it to value.
+    ///
+    /// A counter that is running cannot be set.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate pmc;
+    /// #
+    /// # fn test_main() -> Result<(), pmc::error::Error> {
+    /// # let mut counter =
+    /// #    pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)?;
+    /// 	# counter.attach(0).unwrap();
+    /// #
+    /// # counter.set(42)?;
+    /// # counter.start()?;
+    /// let r1 = counter.read()?;
+    ///
+    /// // Do some stuff...
+    ///
+    /// counter.stop()?;
+    /// # counter.set(4242)?;
+    /// let r2 = counter.set(0)?;
+    /// let r3 = counter.read()?;
+    ///
+    /// assert!(r2 != 0);
+    /// assert!(r2 > r1);
+    /// assert!(r3 == 0);
+    /// #
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   test_main().unwrap();
+    /// # }
+    /// ```
+    pub fn set(&mut self, value: u64) -> Result<u64, Error> {
+        signal::check()?;
 
-		let mut old: u64 = 0;
-		if unsafe { pmc_rw(self.pmc_id.unwrap(), value, &mut old) } != 0 {
-			return match io::Error::raw_os_error(&io::Error::last_os_error()) {
-				Some(libc::EBUSY) => Err(new_os_error(ErrorKind::Running)),
-				_ => Err(new_os_error(ErrorKind::Unknown)),
-			};
-		}
+        let mut old: u64 = 0;
+        if unsafe { pmc_rw(self.pmc_id.unwrap(), value, &mut old) } != 0 {
+            return match io::Error::raw_os_error(&io::Error::last_os_error()) {
+                Some(libc::EBUSY) => Err(new_os_error(ErrorKind::Running)),
+                _ => Err(new_os_error(ErrorKind::Unknown)),
+            };
+        }
 
-		Ok(old)
-	}
+        Ok(old)
+    }
 }
 
 impl<'a> Drop for Counter<'a> {
-	fn drop(&mut self) {
-		if self.pmc_id.is_none() {
-			return;
-		}
+    fn drop(&mut self) {
+        if self.pmc_id.is_none() {
+            return;
+        }
 
-		// Stop an active PMC counter before releasing
-		if self.running {
-			let _ = self.stop();
-		}
+        // Stop an active PMC counter before releasing
+        if self.running {
+            let _ = self.stop();
+        }
 
-		unsafe {
-			pmc_release(self.pmc_id.unwrap());
-		}
-	}
+        unsafe {
+            pmc_release(self.pmc_id.unwrap());
+        }
+    }
 }

--- a/tests/pmc.rs
+++ b/tests/pmc.rs
@@ -4,71 +4,71 @@ use pmc::error::*;
 
 #[test]
 fn test_process_counter() {
-	let mut counter = pmc::Counter::new("unhalted-cycles", &pmc::Scope::Process, pmc::CPU_ANY)
-		.expect("failed to create counter");
+    let mut counter = pmc::Counter::new("PAGE_FAULT.ALL", &pmc::Scope::Process, pmc::CPU_ANY)
+        .expect("failed to create counter");
 
-	read_counter(&mut counter);
+    read_counter(&mut counter);
 }
 
 #[test]
 #[ignore]
 fn test_system_counter() {
-	let mut counter =
-		pmc::Counter::new("cycles", &pmc::Scope::System, 0).expect("failed to create counter");
+    let mut counter =
+        pmc::Counter::new("cycles", &pmc::Scope::System, 0).expect("failed to create counter");
 
-	read_counter(&mut counter);
+    read_counter(&mut counter);
 }
 
 #[test]
 fn test_set_counter() {
-	let mut counter = pmc::Counter::new("LOCK.FAILED", &pmc::Scope::Process, pmc::CPU_ANY)
-		.expect("failed to create counter");
+    let mut counter = pmc::Counter::new("LOCK.FAILED", &pmc::Scope::Process, pmc::CPU_ANY)
+        .expect("failed to create counter");
 
-	counter.set(42).expect("failed to set counter");
-	assert_eq!(counter.read().unwrap(), 42);
-	assert_eq!(counter.set(4242).unwrap(), 42);
+    counter.set(42).expect("failed to set counter");
+    assert_eq!(counter.read().unwrap(), 42);
+    assert_eq!(counter.set(4242).unwrap(), 42);
 }
 
 #[test]
 fn test_counter_bad_name() {
-	assert_eq!(
-		pmc::Counter::new("wat", &pmc::Scope::Process, pmc::CPU_ANY)
-			.unwrap_err()
-			.kind(),
-		&ErrorKind::AllocInit
-	);
+    assert_eq!(
+        pmc::Counter::new("wat", &pmc::Scope::Process, pmc::CPU_ANY)
+            .unwrap_err()
+            .kind(),
+        &ErrorKind::AllocInit
+    );
 }
 
 #[test]
 fn test_null_in_counter_name() {
-	assert_eq!(
-		pmc::Counter::new("instru\0ctions", &pmc::Scope::Process, pmc::CPU_ANY)
-			.unwrap_err()
-			.kind(),
-		&ErrorKind::InvalidEventSpec
-	);
+    assert_eq!(
+        pmc::Counter::new("instru\0ctions", &pmc::Scope::Process, pmc::CPU_ANY)
+            .unwrap_err()
+            .kind(),
+        &ErrorKind::InvalidEventSpec
+    );
 }
 
 #[test]
 fn test_attach_to_pid() {
-	let mut counter = pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)
-		.expect("failed to create counter");
+    let mut counter = pmc::Counter::new("instructions", &pmc::Scope::Process, pmc::CPU_ANY)
+        .expect("failed to create counter");
 
-	// pmc_attach treats 0 as "attach to self"
-	counter.attach(0).expect("failed to attach to self");
+    // pmc_attach treats 0 as "attach to self"
+    counter.attach(0).expect("failed to attach to self");
 
-	read_counter(&mut counter);
+    read_counter(&mut counter);
 }
 
 fn read_counter(c: &mut pmc::Counter) {
-	c.start().expect("failed to start counter");
+    c.start().expect("failed to start counter");
 
-	let mut last: u64 = 0;
-	for _ in 1..100 {
-		let now = c.read().expect("unable to read counter");
-		if now < last {
-			panic!("counter decremented")
-		}
-		last = now;
-	}
+    let mut last: u64 = 0;
+    for _ in 1..100 {
+        let now = c.read().expect("unable to read counter");
+        if now < last {
+            panic!("counter decremented")
+        }
+        last = now;
+    }
 }


### PR DESCRIPTION
Adds a CI pipeline, largely thanks to @asomers in #5 / #11.

---

* Add basic CI with Cirrus (41aebf3) - authored by @asomers 


* ci: fix Cirrus CI pipeline (d9d0b55)

      Disables execution on FreeBSD 12 & 13 pending support for the updated libpmc
      interface (#7).

      Cirrus CI uses Google Cloud to run their FreeBSD VMs [1], and while I cannot
      find any official statement regarding PMC support within GCP there are multiple
      reports of Linux's "perf" tool not collecting counter values on GCP VMs [2], so
      it seems likely their hypervisor does not expose them.

      To have a usable CI pipeline, this change amends the tests to use software
      counters rather than real CPU PMCs. While this means the tests are not a
      complete e2e including hardware support, it does at least exercise & validate
      the integration with libpmc.

      [1]: https://cirrus-ci.org/guide/FreeBSD/
      [2]: https://stackoverflow.com/questions/40180636/linux-perf-events-profiling-in-google-compute-engine-not-working