### PR TITLE
Update FreeBSD 13 CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,8 @@
 task:
   matrix:
-    # - name: FreeBSD 11
-    #   freebsd_instance:
-    #     image: freebsd-11-4-release-amd64
-    # - name: FreeBSD 12
-    #   freebsd_instance:
-    #     image: freebsd-12-2-release-amd64
     - name: FreeBSD 13
       freebsd_instance:
-        image: freebsd-13-2-release-amd64
+        image: freebsd-13-3-release-amd64
 
   setup_script:
     - pkg install -y llvm


### PR DESCRIPTION
And remove long-EoL FreeBSD 11 and 12 CI jobs, already commented-out.  It would be a good idea to add FreeBSD 14 and 15 testing too, but that's beyond the scope of this PR.